### PR TITLE
Crunchy should not irclink his own links from hubot

### DIFF
--- a/lib/Jarvis/Persona/Crunchy.pm
+++ b/lib/Jarvis/Persona/Crunchy.pm
@@ -658,6 +658,7 @@ sub link{
     my $nick=shift if @_;
     return undef unless $url;
     return undef unless $nick;
+    return undef if ($nick =~ /crunchy/ );
     # return undef if $url =~ m#^https://gist.github.com#i; # ! should get this now
     print STDERR "[ $url ]\n";
     my $agent = LWP::UserAgent->new();


### PR DESCRIPTION
Prior to this commit, when somebody asked crunchy for something via the
'img me' interface command set, crunchy would do the needful, but then
also post the returned URI to tumble as user crunchy. These links are
usually more for fun and less of an important part to tumble. So, this
small fix disables that.
