### PR TITLE
Remove the unison responder

### DIFF
--- a/lib/Jarvis/Persona/Crunchy.pm
+++ b/lib/Jarvis/Persona/Crunchy.pm
@@ -211,8 +211,7 @@ sub input{
                                               };
             /global business excellence/i
                                         && do { $replies = [ "Unison!" ]; last; };
-            /unison/i                   && do { $replies = [ "The Way To Global Business Excellence!" ]; last; };
-            /scotch/i           && do {
+            /scotch/i                   && do {
                                                 $pirate=0;
                                                 eval {
                                                        if($direct){


### PR DESCRIPTION
The Unison responder has been replaced by the one in crunch-ng commit
44c838f. This simply removes that code. Note that the 'way to global
business excellence' with crunchy responding Unison is still enabled as
I don't think that was ported over.
