### PR TITLE
Fix deployments

### DIFF
--- a/lib/Jarvis/Persona/Crunchy.pm
+++ b/lib/Jarvis/Persona/Crunchy.pm
@@ -137,6 +137,8 @@ sub input{
             /\"(.+?)\"\s+--\s*(.+?)$/    && do { $replies = [ $self->quote($what) ]; last; };
              /(https*:\S+)/ && !/!http/  && do { $replies = [ $self->link($1, $who) ]; last; };
             /^\s*[Ff]ortune\s*$/         && do { $replies = [ $self->fortune() ]; last; };
+            /^!legacy-bot-deploy\s*$/    && do { $replies = [ $self->deploy() ]; last; };
+            /^!legacy-bot-reload\s*$/    && do { $replies = [ $self->reload() ]; last; };
             /^!shoutout\s*(.*)/          && do { $replies = [ $self->shoutout($1,$who) ]; last; };
             /^!enable\s+shoutouts.*/     && do {
                                                 $msg->{'reason'}='enable_shoutout';
@@ -671,6 +673,28 @@ sub fortune{
     return $fortune;
 }
 
+sub deploy{
+    my $self=shift;
+    my $output;
+    if(-x "/usr/local/bin/legacy-bot-reload") {
+        # We have to use SSH because sudo is effed on freyr
+        $output = qx(ssh -i /home/opt/.ssh/id_rsa_deploy root\@localhost "/usr/local/bin/legacy-bot-reload deploy");
+    }
+    return $output;
+}
+
+sub reload{
+    my $self=shift;
+    my $output;
+    if(-x "/usr/local/bin/legacy-bot-reload") {
+        # We have to use SSH because sudo is effed on freyr
+        $output = qx(ssh -i /home/opt/.ssh/id_rsa_reload root\@localhost "/usr/local/bin/legacy-bot-reload reload");
+    }
+    return $output;
+}
+
+
+
 sub link{
     my $self=shift;
     my $url=shift if @_;
@@ -1011,6 +1035,14 @@ sub help {
                   'tumble'    => [
                                    "description: Our tumblelog",
                                    "syntax/use : http://tumble.wcyd.org/",
+                                 ],
+                 'legacy-bot-deploy'    => [
+                                   'description: redeploy classic perl crunchy after pulling from github',
+                                   'syntax/use : !legacy-bot-deploy',
+                                 ],
+                 'legacy-bot-reload'    => [
+                                   'description: reload classic perl crunchy',
+                                   'syntax/use : !legacy-bot-reload',
                                  ],
 #                  'twitter'   => [
 #                                   "description: enable/disable twitter",


### PR DESCRIPTION
We're gonna chatops like it's 2004 up in here.

We wanted a way to deploy and reload crunchy from the CLI. In this case
we'll just pass it off to IRC. The helpers makes use of a new script I
wrote on freyr at `/usr/local/bin/legacy-bot-reload`. This script is
pretty basic and has minimal error checking. I haven't included it in
this pull request, because the entire thing is quite a hack.

Right now we must use ssh keys with force-commands (2 keys, one for
deploy and one for reload) authenticating as root, becuase James S White
effed up our sudo on freyr.  Until that is fixed, this is the best way I
could think of to solve the problem.

The bot should respond to:

```
!legacy-bot-deploy
```

This is congruent to:
  cd /opt/local/jarvis && git pull && service jarvis restart

There is also

```
!legacy-bot-reload
```

This maps to:
  service jarvis restart

The main issue with this commit is that there is no logging of what
happened. The only thing you can really see is the PID change, or you
can watch /var/log/secure for some ssh traffic. Meh. It's legacy.
